### PR TITLE
C Versions for temporalmemory and deeptemporalmemory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+chessweb01
+sparseassociativememory.c

--- a/C/deeptemporalmemory.c
+++ b/C/deeptemporalmemory.c
@@ -225,7 +225,7 @@ int main(int argc, char *argv[])
 	sscanf( argv[1], "%d", &N);
 	sscanf( argv[2], "%d", &P);
     
-    	DeepTemporalMemory *T = deeptemporalmemory_new (N, P);
+	DeepTemporalMemory *T = deeptemporalmemory_new (N, P);
    
 	SDR *inp = sdr_new(N);
 	SDR *out = sdr_new(N);

--- a/C/deeptemporalmemorytest.c
+++ b/C/deeptemporalmemorytest.c
@@ -1,0 +1,250 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "triadicmemory.h"
+#include "encoders.h"
+
+typedef struct
+{
+	TriadicMemory* T;
+	SDR* x, * y, * z, * u;
+} TemporalBigramEncoder;
+
+TemporalBigramEncoder* temporalbigramencoder_new(int n, int p);	// constructor
+SDR* temporalbigramencoder(TemporalBigramEncoder*, SDR*);		// predictor
+
+
+TemporalBigramEncoder* temporalbigramencoder_new(int n, int p)
+{
+	TemporalBigramEncoder* R = malloc(sizeof(TemporalBigramEncoder));
+
+	R->T = triadicmemory_new(n, p);
+
+	R->x = sdr_new(n);	// persistent circuit state variables
+	R->y = sdr_new(n);
+	R->z = sdr_new(n);
+
+	R->u = sdr_new(n);	// temporary variable
+	return R;
+}
+
+
+SDR* temporalbigramencoder(TemporalBigramEncoder* R, SDR* inp)
+{
+	// flush state variables if input is zero -- needed for usage as sequence memory
+	if (inp->p == 0)
+	{
+		R->x->p = R->y->p = R->z->p = 0;
+		return R->z;
+	}
+
+	sdr_or(R->x, R->y, R->z);
+	sdr_set(R->y, inp);
+
+	if (R->x->p == 0)
+		return R->z;
+
+	triadicmemory_read_z(R->T, R->x, R->y, R->z); // recall z
+	triadicmemory_read_x(R->T, R->u, R->y, R->z); // recall u (temp variable)
+
+	if (sdr_overlap(R->x, R->u) < R->T->px)
+	{
+		sdr_random(R->z, R->T->pz);
+		triadicmemory_write(R->T, R->x, R->y, R->z);
+	}
+
+	return R->z;
+}
+
+
+typedef struct
+{
+	TriadicMemory* M;
+	SDR* x, * y, * z;
+
+	TemporalBigramEncoder* R1, * R2, * R3, * R4, * R5, * R6, * R7;
+	SDR* t1, * t2, * t3, * t4, * t5, * t6, * t7;
+
+} DeepTemporalMemory;
+
+
+DeepTemporalMemory* deeptemporalmemory_new(int n, int p);	// constructor
+SDR* deeptemporalmemory(DeepTemporalMemory*, SDR*);		// predictor
+
+
+DeepTemporalMemory* deeptemporalmemory_new(int n, int p)
+{
+	DeepTemporalMemory* D = malloc(sizeof(DeepTemporalMemory));
+
+	D->M = triadicmemory_new(n, p);
+
+	D->x = sdr_new(n);
+	D->y = sdr_new(n);
+	D->z = sdr_new(n);
+
+	D->R1 = temporalbigramencoder_new(n, p);
+	D->R2 = temporalbigramencoder_new(n, p);
+	D->R3 = temporalbigramencoder_new(n, p);
+	D->R4 = temporalbigramencoder_new(n, p);
+	D->R5 = temporalbigramencoder_new(n, p);
+	D->R6 = temporalbigramencoder_new(n, p);
+	D->R7 = temporalbigramencoder_new(n, p);
+
+	D->t1 = sdr_new(n);
+	D->t2 = sdr_new(n);
+	D->t3 = sdr_new(n);
+	D->t4 = sdr_new(n);
+	D->t5 = sdr_new(n);
+	D->t6 = sdr_new(n);
+	D->t7 = sdr_new(n);
+
+	return D;
+}
+
+
+SDR* deeptemporalmemory(DeepTemporalMemory* D, SDR* inp)
+{
+	// if inp is zero, all state variables will go to zero in this function pass
+
+
+	// prediction not correct? store new prediction
+
+	if (!sdr_equal(D->z, inp))
+		triadicmemory_write(D->M, D->x, D->y, inp);
+
+	// TemporalBigramEncoding chain
+
+	D->t1 = temporalbigramencoder(D->R1, inp);	// t1 is a temporal 2gram
+	D->t2 = temporalbigramencoder(D->R2, D->t1);
+	D->t3 = temporalbigramencoder(D->R3, D->t2);
+	D->t4 = temporalbigramencoder(D->R4, D->t3);
+	D->t5 = temporalbigramencoder(D->R5, D->t4);
+	D->t6 = temporalbigramencoder(D->R6, D->t5);
+	D->t7 = temporalbigramencoder(D->R7, D->t6); 	// t7 is a temporal 8gram
+
+	// prediction based on readout from t1, t2, t4 and t7 (other combinations work as well)
+
+	sdr_or(D->x, D->t1, D->t4);
+	sdr_or(D->y, D->t2, D->t7);
+
+	return triadicmemory_read_z(D->M, D->x, D->y, D->z);
+	// important: the return value is used in the next iteration and should not be changed by
+	// the embedding function
+}
+
+void main(int argc, char* argv[])
+{
+	/*
+	// Prepare data set: remove delimiters -1 and -2 from original data set
+	FILE* pIn = fopen("SIGN.txt", "r");
+
+	if (!pIn) {
+		printf("Cannot open file SIGN.txt\n\n");
+		return;
+	}
+
+	FILE* pOut = fopen("SIGN_processed.txt", "w");
+
+	int val;
+
+	while (fscanf(pIn, "%i", &val) == 1) {
+		if (val != -1 && val != -2) {
+			//printf("%i ", val);
+			fprintf(pOut, "%i ", val);
+		}
+
+		// next sequence
+		if (val == -2) {
+			fprintf(pOut, "\n", val);
+		}
+	}
+
+	fclose(pIn);
+	fclose(pOut);
+	*/
+
+	int N, P, Min = 0, Max = 500, iter = 0;
+
+	sscanf(argv[1], "%i", &N);
+	sscanf(argv[2], "%i", &P);
+
+	FILE* pIn = fopen("SIGN_processed.txt", "r");
+
+	if (!pIn) {
+		printf("Can't open SIGN_processed.txt\n\n");
+		return;
+	}
+
+	FILE* pOut = fopen("results.txt", "w");
+
+	char* sequence = (char*)malloc(500 * sizeof(char));
+	int val, val_count = 0, correct = 0, total = 0, pred_old = 0, sequ = 0;
+	SDR* inp = sdr_new(N);
+	DeepTemporalMemory* T = deeptemporalmemory_new(N, P);
+
+	while (iter++ < 8) {
+
+		total = 0;		// counts predicted values per iteration
+		correct = 0;	// counts correct predictions per iteration
+		sequ = 0;		// counts sequences per iteration
+
+		// process sequences one by one
+		while (fgets(sequence, 500, pIn) != NULL) {
+
+			printf("iteration %i sequence %i\n", iter, ++sequ);
+
+			val_count = 0;	// counts values per sequence
+
+			// save sequence start address for later recovery
+			char* tmp = sequence;
+				
+			// extract and process values from sequence one by one
+			while (sscanf(sequence, "%i", &val) == 1) {
+
+				//printf("%i ", val);
+
+				if (val < Min || val > Max) {
+					printf("Value out of range\n\n");
+					return;
+				}
+				
+				val_count++;
+
+				// value -> SDR
+				Int2SDR(inp, val, N, P, Min, Max);
+
+				// predict next value
+				int pred = SDR2Int(deeptemporalmemory(T, inp), N, P, Min, Max);
+
+				if (pred_old == val) correct++;
+				if (val_count > 3) total++;		// don't count first three values in sequence
+
+				pred_old = pred;
+
+				// move pointer to next value (the sequence start address is lost here,
+				// but has been saved above to recover it for the next sequence)
+				while (*(++sequence) != ' ');	
+			}
+
+			// recover sequence start address for the next sequence
+			sequence = tmp;
+
+			// flush memory state
+			deeptemporalmemory(T, sdr_new(N));
+		}
+
+		printf("\niteration %i\n", iter);
+		printf("%f percent correct\n\n", 100.0 * (float)correct / (float)total);
+
+		fprintf(pOut, "iteration %i\n", iter);
+		fprintf(pOut, "%f percent correct\n\n", 100.0 * (float)correct / (float)total);
+
+		rewind(pIn);
+	}
+
+	free(sequence);
+
+	fclose(pIn);
+	fclose(pOut);
+}

--- a/C/dyadicmemorytest.c
+++ b/C/dyadicmemorytest.c
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
 
 		printf("read ");
 		start = clock();
-		int h[size];
+		int* h = (int *)malloc(size * sizeof(int));
 		for (int i = 0; i < size; i++)
 			dyadicmemory_read ( T, t1[i], out[i] );
 		
@@ -104,6 +104,8 @@ int main(int argc, char *argv[])
 		double mh = 0;
 		for (int i = 0; i < size; i++) mh += h[i];
 		printf("%.3f err\n",   mh/size);
+
+		free(h);
 		}
 
 	printf("finished\n");

--- a/C/encoders.c
+++ b/C/encoders.c
@@ -1,0 +1,102 @@
+#include <stdlib.h>
+#include <math.h>
+
+#include "triadicmemory.h"
+#include "encoders.h"
+
+static int cmpfunc(const void* a, const void* b)
+{
+	return  *(int*)a - *(int*)b;
+}
+
+static double Round(double x, double a)
+{
+	if (x / a - (int)(x / a) < 0.5)
+		return floor(x / a) * a;
+	else
+		return ceil(x / a) * a;
+}
+
+/*
+* Floor[x], gives the greatest integer less than or equal to x.
+* SparseArray[data, { d1,d2,... }], yields a sparse array representing a d1×d2×... array.
+* RotateRight[expr, n], cycles the elements in expr n positions to the right.
+* PadRight[list, n], makes a list of length n by padding list with zeros on the right.
+* Table[expr, n], generates a list of n copies of expr.
+*
+* Flatten[list], flattens out nested lists.
+* If[condition,t,f], gives t if condition evaluates to True, and f if it evaluates to False.
+* N[expr], gives the numerical value of expr.
+* Round[x,a], rounds to the nearest multiple of a.
+* Mean[list], gives the statistical mean of the elements in list.
+* Boole[expr], yields 1 if expr is True and 0 if it is False.
+* OddQ[expr], gives True if expr is an odd integer, and False otherwise.
+*/
+
+/*
+Mathematica: 
+------------
+Real2SDR[x_, { xmin_, xmax_ }, { n_Integer, p_Integer }] :=
+	Module[{m},
+		m = Floor[(x - xmin) / (xmax - xmin) * (n - p)];
+
+		SparseArray[
+			RotateRight[
+				PadRight[
+					Table[1, p], n
+				], m
+			], { n }
+		]
+	];
+*/
+SDR* Real2SDR(SDR* s, double x, int n, int p, double xmin, double xmax) 
+{
+	s->p = p;
+
+	int m = (int)floor((x - xmin) / (xmax - xmin) * ((double)n - (double)p));
+
+	for (int i = 0; i < p; i++) {
+		s->a[i] = i + m;
+	}
+
+	qsort(s->a, p, sizeof(int), cmpfunc);
+
+	return s;
+}
+
+/*
+Mathematica:
+------------
+SDR2Real[x_SparseArray, { xmin_, xmax_ }, { n_Integer, p_Integer }] :=
+	Module[{a},
+		a = Flatten[x["NonzeroPositions"]];
+
+		If[Length[a] == 0,
+			0,
+			N[
+				Round[
+					(Mean[a] - (p + 1) / 2) / (n - p), 1 / (n - p - Boole[OddQ[n - p]])
+				] * (xmax - xmin) + xmin
+			]
+		]
+	];
+*/
+double SDR2Real(SDR* s, int n, int p, double xmin, double xmax) 
+{
+	int sum = 0;
+
+	for (int i = 0; i < p; i++) {
+		if (s->a[i] != 0) break;
+		if (i == p - 1) return 0.0;
+	}
+
+	for (int i = 0; i < p; i++) {
+		sum += s->a[i];
+	}
+
+	double Mean = (double)sum / (double)p;
+
+	double Boole = (n - p) % 2 == 0 ? 0.0 : 1.0;
+
+	return Round((Mean - ((double)p + 1.0) / 2.0) / ((double)n - (double)p), 1.0 / ((double)n - (double)p - Boole)) * (xmax - xmin) + xmin;
+}

--- a/C/encoders.c
+++ b/C/encoders.c
@@ -64,6 +64,11 @@ SDR* Real2SDR(SDR* s, double x, int n, int p, double xmin, double xmax)
 	return s;
 }
 
+SDR* Int2SDR(SDR* s, int x, int n, int p, int xmin, int xmax)
+{
+	return Real2SDR(s, (double)x, n, p, (double)xmin, (double)xmax);
+}
+
 /*
 Mathematica:
 ------------
@@ -99,4 +104,9 @@ double SDR2Real(SDR* s, int n, int p, double xmin, double xmax)
 	double Boole = (n - p) % 2 == 0 ? 0.0 : 1.0;
 
 	return Round((Mean - ((double)p + 1.0) / 2.0) / ((double)n - (double)p), 1.0 / ((double)n - (double)p - Boole)) * (xmax - xmin) + xmin;
+}
+
+int SDR2Int(SDR* s, int n, int p, int xmin, int xmax) 
+{
+	return (int)ceil(SDR2Real(s, n, p, (double)xmin, (double)xmax));
 }

--- a/C/encoders.h
+++ b/C/encoders.h
@@ -3,3 +3,5 @@
 double Round(double, double);
 SDR* Real2SDR(SDR*, double, int, int, double, double);
 double SDR2Real(SDR*, int, int, double, double);
+SDR* Int2SDR(SDR*, int, int, int, int, int);
+int SDR2Int(SDR*, int, int, int, int);

--- a/C/encoders.h
+++ b/C/encoders.h
@@ -1,0 +1,5 @@
+#pragma once
+
+double Round(double, double);
+SDR* Real2SDR(SDR*, double, int, int, double, double);
+double SDR2Real(SDR*, int, int, double, double);

--- a/C/encoderstest.c
+++ b/C/encoderstest.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "triadicmemory.h"
+#include "encoders.h"
+
+int main(int argc, char* argv[]) 
+{
+	/*
+		Test with n = 10000, p = 10, xmin = -10.0, xmax = 10.0
+	*/
+
+	SDR* sdr = sdr_new(10000);
+
+	for (double x = -10.0; x <= 10.0; x += 0.01) {
+
+		printf("value before encoding to sdr: %.2f\nsdr: ", x);
+		
+		Real2SDR(sdr, x, 10000, 10, -10.0, 10.0);
+
+		sdr_print(sdr);
+
+		printf("value after decoding from sdr: %f\n\n", SDR2Real(sdr, 10000, 10, -10.0, 10.0));
+	}
+
+	sdr_delete(sdr);
+
+	return 0;
+}

--- a/C/encoderstest.c
+++ b/C/encoderstest.c
@@ -12,6 +12,8 @@ int main(int argc, char* argv[])
 
 	SDR* sdr = sdr_new(10000);
 
+	printf("Testing Real2SDR / SDR2Real\n\n");
+
 	for (double x = -10.0; x <= 10.0; x += 0.01) {
 
 		printf("value before encoding to sdr: %.2f\nsdr: ", x);
@@ -20,7 +22,22 @@ int main(int argc, char* argv[])
 
 		sdr_print(sdr);
 
-		printf("value after decoding from sdr: %f\n\n", SDR2Real(sdr, 10000, 10, -10.0, 10.0));
+		double tmp = SDR2Real(sdr, 10000, 10, -10.0, 10.0);
+
+		printf("value after decoding from sdr: %.2f (%f)\n\n", tmp, tmp);
+	}
+
+	printf("Testing Int2SDR / SDR2Int\n\n");
+
+	for (int x = 0; x <= 267; x++) {
+
+		printf("value before encoding to sdr: %i\nsdr: ", x);
+
+		Int2SDR(sdr, x, 10000, 10, 0, 267);
+
+		sdr_print(sdr);
+
+		printf("value after decoding from sdr: %i\n\n", SDR2Int(sdr, 10000, 10, 0, 267));
 	}
 
 	sdr_delete(sdr);

--- a/C/temporalmemory.c
+++ b/C/temporalmemory.c
@@ -154,7 +154,7 @@ int main(int argc, char *argv[])
 	sscanf( argv[1], "%d", &N);
 	sscanf( argv[2], "%d", &P);
     
-    	TemporalMemory *T = temporalmemory_new (N, P);
+    TemporalMemory *T = temporalmemory_new (N, P);
    
 	SDR *inp = sdr_new(N);
 	SDR *out = sdr_new(N);

--- a/C/temporalmemorytest.c
+++ b/C/temporalmemorytest.c
@@ -1,0 +1,103 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "triadicmemory.h"
+#include "encoders.h"
+
+typedef struct
+{
+	TriadicMemory* M1, * M2;
+	SDR* x, * y, * c, * u, * v, * prediction;
+} TemporalMemory;
+
+TemporalMemory* temporalmemory_new(int n, int p);	// constructor
+SDR* temporalmemory(TemporalMemory*, SDR*);			// predictor
+
+TemporalMemory* temporalmemory_new(int n, int p)
+{
+	TemporalMemory* T = (TemporalMemory * )malloc(sizeof(TemporalMemory));
+
+	T->M1 = triadicmemory_new(n, p);
+	T->M2 = triadicmemory_new(n, p);
+
+	T->x = sdr_new(n);	// persistent circuit state variables
+	T->y = sdr_new(n);
+	T->c = sdr_new(n);
+	T->u = sdr_new(n);
+	T->v = sdr_new(n);
+	T->prediction = sdr_new(n);
+
+	return T;
+}
+
+SDR* temporalmemory(TemporalMemory* T, SDR* inp)
+{
+	// flush state variables if input is zero -- needed for usage as sequence memory
+	if (inp->p == 0)
+	{
+		T->y->p = T->c->p = T->u->p = T->v->p = T->prediction->p = 0;
+		return T->prediction;
+	}
+
+	sdr_or(T->x, T->y, T->c);
+	sdr_set(T->y, inp);
+
+	if (!sdr_equal(T->prediction, T->y))
+		// less aggressive test: if ( sdr_overlap (T->prediction, T->y) < T->M2->p)
+		triadicmemory_write(T->M2, T->u, T->v, T->y);
+
+	triadicmemory_read_z(T->M1, T->x, T->y, T->c); // recall c
+	triadicmemory_read_x(T->M1, T->u, T->y, T->c); // recall u
+
+	if (sdr_overlap(T->x, T->u) < T->M1->px)
+	{
+		sdr_random(T->c, T->M1->pz);
+		triadicmemory_write(T->M1, T->x, T->y, T->c);
+	}
+
+	return triadicmemory_read_z(T->M2, sdr_set(T->u, T->x), sdr_set(T->v, T->y), T->prediction);
+	// important: the return value is used in the next iteration and should not be changed by
+	// the embedding function
+}
+
+void main(int argc, char* argv[])
+{
+	int N, P, Min = 0, Max = 120, man, count = 0, iter = 0;
+
+	sscanf(argv[1], "%i", &N);
+	sscanf(argv[2], "%i", &P);
+	sscanf(argv[3], "%i", &man);	// 1: waits for ENTER for next prediction
+									// 0: predicts continuously
+
+	char str[7] = { 'b', 'a', 'n', 'a', 'n', 'a' };
+
+	SDR* inp = sdr_new(N);
+
+	TemporalMemory* T = temporalmemory_new(N, P);
+
+	while (1) {
+		if (count == 0) {
+			printf("Iteration: %i\n", iter++);
+		}
+
+		int in = (int)str[count];
+
+		count = ++count % strlen(str);
+
+		printf("input: %i -> ", in);
+
+		Int2SDR(inp, in, N, P, Min, Max);
+
+		int pred = SDR2Int(temporalmemory(T, inp), N, P, Min, Max);
+
+		printf("prediction: %i ", pred);
+
+		if (iter == 1) printf("./.");
+		else if (pred == str[count]) printf("correct");
+		else printf("not correct");
+
+		if (man == 1) getc(stdin);
+		else printf("\n");
+	}
+}

--- a/C/triadicmemory.h
+++ b/C/triadicmemory.h
@@ -27,6 +27,8 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ---------- SDR data type and utility functions ----------
 
 	
+#include <stdint.h>
+
 typedef struct
 	{
 	int 	*a,	// indices of non-zero positions, stored in array of size n

--- a/C/triadicmemorytest.c
+++ b/C/triadicmemorytest.c
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
 	
 		printf("%.2fs | ", ((double) (clock() - start)) / CLOCKS_PER_SEC);
 
-		int h[size];
+		int* h = (int *)malloc(size * sizeof(int));
 		double mh;
 
 		// recall z
@@ -145,6 +145,8 @@ int main(int argc, char *argv[])
 			printf("%.3f err", mh/size);
 			}
 		
+		free(h);
+
 		printf("\n");
 		}
 


### PR DESCRIPTION
**_temporalmemorytest.c_** demonstrates **_temporalmemory.m_** with the example from **_Deep Temporal Memory - Introduction.pdf_**.
**_deeptemporalmemorytest.c_** demonstrates **_deeptemporalmemory.m_** for the SPMF sequences from **_Deep Temporal Memory - SPMF Sequence Example.pdf_**.

Both programs depend on **_encoders.c_** which replicates **_encoders.m_**.

Results for the SPMF sequences:

iteration 1
3.134086 percent correct

iteration 2
72.310445 percent correct

iteration 3
94.098076 percent correct

iteration 4
98.322523 percent correct

iteration 5
99.331805 percent correct

iteration 6
99.630955 percent correct

iteration 7
99.658913 percent correct

iteration 8
99.661709 percent correct
